### PR TITLE
Add tornado spiral sculpture

### DIFF
--- a/tornado.scad
+++ b/tornado.scad
@@ -1,0 +1,85 @@
+// === PARAMETERS ===
+turns = 12;
+height = 200;
+min_radius = 5;
+max_radius = 50;
+strip_thickness = 1.2;
+strip_width = 2.5;
+segments_per_turn = 60;
+hook_radius = 6;
+hook_thickness = 1.5;
+bridge_height = 8;
+
+// === FUNNEL SPIRAL (wide → narrow) ===
+module funnel_spiral() {
+  step_angle = 360 / segments_per_turn;
+  total_steps = turns * segments_per_turn;
+  z_step = height / total_steps;
+
+  for (i = [0 : total_steps - 2]) {
+    angle1 = i * step_angle;
+    angle2 = (i + 1) * step_angle;
+
+    r1 = max_radius - (max_radius - min_radius) * (i / total_steps);
+    r2 = max_radius - (max_radius - min_radius) * ((i + 1) / total_steps);
+
+    x1 = r1 * cos(angle1);
+    y1 = r1 * sin(angle1);
+    z1 = height - i * z_step;
+
+    x2 = r2 * cos(angle2);
+    y2 = r2 * sin(angle2);
+    z2 = height - (i + 1) * z_step;
+
+    hull() {
+      translate([x1, y1, z1])
+        cube([strip_width, strip_thickness, strip_thickness], center=true);
+      translate([x2, y2, z2])
+        cube([strip_width, strip_thickness, strip_thickness], center=true);
+    }
+  }
+}
+
+// === RETURN BRIDGE TO CENTER ===
+module return_bridge_to_center() {
+  steps = 30;
+  for (i = [0 : steps - 2]) {
+    t1 = i / steps;
+    t2 = (i + 1) / steps;
+
+    r1 = max_radius * (1 - t1);
+    r2 = max_radius * (1 - t2);
+
+    angle1 = 360 * t1;
+    angle2 = 360 * t2;
+
+    x1 = r1 * cos(angle1);
+    y1 = r1 * sin(angle1);
+    z1 = height + bridge_height * sin(t1 * 180);
+
+    x2 = r2 * cos(angle2);
+    y2 = r2 * sin(angle2);
+    z2 = height + bridge_height * sin(t2 * 180);
+
+    hull() {
+      translate([x1, y1, z1])
+        cube([strip_width, strip_thickness, strip_thickness], center=true);
+      translate([x2, y2, z2])
+        cube([strip_width, strip_thickness, strip_thickness], center=true);
+    }
+  }
+}
+
+// === CENTER HOOK ===
+module hook() {
+  translate([0, 0, height + bridge_height + 3])
+    rotate([90, 0, 0])
+      rotate_extrude(angle=300)
+        translate([hook_radius, 0])
+          square([hook_thickness, hook_thickness]);
+}
+
+// === ASSEMBLY ===
+funnel_spiral();
+return_bridge_to_center();
+// hook();

--- a/tornado.scad
+++ b/tornado.scad
@@ -2,6 +2,7 @@
 turns = 8;
 segments_per_turn = 60;
 total_segments = turns * segments_per_turn;
+max_i = total_segments - 2;
 
 end_radius = 100;
 height = 0;
@@ -9,8 +10,8 @@ height = 0;
 min_width = 1;
 max_width = 4;
 
-min_thickness = 3;
-max_thickness = 8;
+min_thickness = 0.1;
+max_thickness = 10;
 
 strip_thickness_y = 2;
 
@@ -28,13 +29,17 @@ top_attachment_disc();
 
 // === Spiral Function ===
 module spiral_strip_variable_size() {
-  for (i = [0 : total_segments - 2]) {
+  for (i = [0 : max_i]) {
     hull() {
       place_strip(i);
       place_strip(i + 1);
     }
   }
 }
+
+// === Thickness Calculation Function ===
+function calculate_thickness(turns, i, max_i, max_thickness, min_thickness) =
+    (i <= max_i / turns) ? max_thickness : min_thickness + (max_thickness - min_thickness) * pow(1 - pow((i - max_i / turns) / (max_i - max_i / turns), 0.3), 0.3);
 
 // === Strip Placement ===
 module place_strip(i) {
@@ -47,7 +52,7 @@ module place_strip(i) {
   z = 0; // flat, printable
 
   // ✅ Decrease thickness toward center
-  thickness = min_thickness + (max_thickness - min_thickness) * (1 - t);
+  thickness = calculate_thickness(turns, i, max_i, max_thickness, min_thickness);
 
   // ✅ Increase width toward center
   width = min_width + (max_width - min_width) * t;

--- a/tornado.scad
+++ b/tornado.scad
@@ -1,85 +1,97 @@
-// === PARAMETERS ===
+// === Parameters ===
 turns = 12;
-height = 200;
-min_radius = 5;
-max_radius = 50;
-strip_thickness = 1.2;
-strip_width = 2.5;
 segments_per_turn = 60;
-hook_radius = 6;
-hook_thickness = 1.5;
-bridge_height = 8;
+total_segments = turns * segments_per_turn;
 
-// === FUNNEL SPIRAL (wide → narrow) ===
-module funnel_spiral() {
-  step_angle = 360 / segments_per_turn;
-  total_steps = turns * segments_per_turn;
-  z_step = height / total_steps;
+end_radius = 100;
+height = 0;
 
-  for (i = [0 : total_steps - 2]) {
-    angle1 = i * step_angle;
-    angle2 = (i + 1) * step_angle;
+min_width = 3;
+max_width = 8;
 
-    r1 = max_radius - (max_radius - min_radius) * (i / total_steps);
-    r2 = max_radius - (max_radius - min_radius) * ((i + 1) / total_steps);
+min_thickness = 3;
+max_thickness = 8;
 
-    x1 = r1 * cos(angle1);
-    y1 = r1 * sin(angle1);
-    z1 = height - i * z_step;
+strip_thickness_y = 1;
 
-    x2 = r2 * cos(angle2);
-    y2 = r2 * sin(angle2);
-    z2 = height - (i + 1) * z_step;
+center_disc_radius = 6;
+center_disc_thickness = min_thickness; // match outer strip height
+center_hole_radius = 2.5; // 5mm hole
 
+start_radius = center_hole_radius + 1; // e.g. 3.5mm
+
+// === Assembly ===
+spiral_strip_variable_size();
+center_attachment_disc();
+bridge_to_top_disc_aligned();
+top_attachment_disc();
+
+// === Spiral Function ===
+module spiral_strip_variable_size() {
+  for (i = [0 : total_segments - 2]) {
     hull() {
-      translate([x1, y1, z1])
-        cube([strip_width, strip_thickness, strip_thickness], center=true);
-      translate([x2, y2, z2])
-        cube([strip_width, strip_thickness, strip_thickness], center=true);
+      place_strip(i);
+      place_strip(i + 1);
     }
   }
 }
 
-// === RETURN BRIDGE TO CENTER ===
-module return_bridge_to_center() {
-  steps = 30;
-  for (i = [0 : steps - 2]) {
-    t1 = i / steps;
-    t2 = (i + 1) / steps;
+// === Strip Placement ===
+module place_strip(i) {
+  t = i / total_segments;
+  angle = 360 * i / segments_per_turn;
+  radius = start_radius + (end_radius - start_radius) * t;
+  z = height * t;
 
-    r1 = max_radius * (1 - t1);
-    r2 = max_radius * (1 - t2);
+  width = min_width + (max_width - min_width) * t;
+  thickness = min_thickness + (max_thickness - min_thickness) * t;
 
-    angle1 = 360 * t1;
-    angle2 = 360 * t2;
+  translate([radius * cos(angle), radius * sin(angle), 0])
+    rotate([0, 0, angle])
+      cube([width, strip_thickness_y, thickness]);
+}
 
-    x1 = r1 * cos(angle1);
-    y1 = r1 * sin(angle1);
-    z1 = height + bridge_height * sin(t1 * 180);
+// === Central Disc + Hole ===
+module center_attachment_disc() {
+  difference() {
+    // Disc
+    translate([0, 0, 0])
+      cylinder(h=center_disc_thickness, r=center_disc_radius, $fn=100);
 
-    x2 = r2 * cos(angle2);
-    y2 = r2 * sin(angle2);
-    z2 = height + bridge_height * sin(t2 * 180);
-
-    hull() {
-      translate([x1, y1, z1])
-        cube([strip_width, strip_thickness, strip_thickness], center=true);
-      translate([x2, y2, z2])
-        cube([strip_width, strip_thickness, strip_thickness], center=true);
-    }
+    // Hole
+    translate([0, 0, -1])
+      cylinder(h=center_disc_thickness + 2, r=center_hole_radius, $fn=50);
   }
 }
 
-// === CENTER HOOK ===
-module hook() {
-  translate([0, 0, height + bridge_height + 3])
-    rotate([90, 0, 0])
-      rotate_extrude(angle=300)
-        translate([hook_radius, 0])
-          square([hook_thickness, hook_thickness]);
+// === Bridge from spiral end to center (elevated) ===
+module bridge_to_top_disc_aligned() {
+  t = 1;
+  angle = 360 * (total_segments - 1.35) / segments_per_turn;
+  radius = start_radius + (end_radius - start_radius) * t;
+
+  end_x = radius * cos(angle);
+  end_y = radius * sin(angle);
+
+  z = max_thickness / 2;
+
+  // ✅ Add buffer to fully intersect spiral edge
+  len = sqrt(end_x * end_x + end_y * end_y) + max_width - min_width;
+
+  mid_x = end_x / 2;
+  mid_y = end_y / 2;
+
+  translate([mid_x + max_width - min_width, mid_y, z + max_thickness])
+    rotate([0, 0, angle])
+      cube([len, max_width, max_thickness], center=true);
 }
 
-// === ASSEMBLY ===
-funnel_spiral();
-return_bridge_to_center();
-// hook();
+// === New disc at the top (for hanging)
+module top_attachment_disc() {
+  translate([0, 0, max_thickness])
+    difference() {
+      cylinder(h = max_thickness, r = center_disc_radius, $fn=100);
+      translate([0, 0, -1])
+        cylinder(h = max_thickness + 2, r = center_hole_radius, $fn=50);
+    }
+}

--- a/tornado.scad
+++ b/tornado.scad
@@ -1,29 +1,29 @@
 // === Parameters ===
-turns = 12;
+turns = 8;
 segments_per_turn = 60;
 total_segments = turns * segments_per_turn;
 
 end_radius = 100;
 height = 0;
 
-min_width = 3;
-max_width = 8;
+min_width = 1;
+max_width = 4;
 
 min_thickness = 3;
 max_thickness = 8;
 
-strip_thickness_y = 1;
+strip_thickness_y = 2;
 
-center_disc_radius = 6;
+center_disc_radius = 4;
 center_disc_thickness = min_thickness; // match outer strip height
-center_hole_radius = 2.5; // 5mm hole
+center_hole_radius = 2.5;
 
 start_radius = center_hole_radius + 1; // e.g. 3.5mm
 
 // === Assembly ===
-spiral_strip_variable_size();
-center_attachment_disc();
+spiral();
 bridge_to_top_disc_aligned();
+reinforce_bridge_joint();
 top_attachment_disc();
 
 // === Spiral Function ===
@@ -40,50 +40,53 @@ module spiral_strip_variable_size() {
 module place_strip(i) {
   t = i / total_segments;
   angle = 360 * i / segments_per_turn;
-  radius = start_radius + (end_radius - start_radius) * t;
-  z = height * t;
 
+  // Exponential radius shrink toward center (tight inner coils)
+  radius = end_radius * pow(start_radius / end_radius, t) - turns;
+
+  z = 0; // flat, printable
+
+  // ✅ Decrease thickness toward center
+  thickness = min_thickness + (max_thickness - min_thickness) * (1 - t);
+
+  // ✅ Increase width toward center
   width = min_width + (max_width - min_width) * t;
-  thickness = min_thickness + (max_thickness - min_thickness) * t;
 
-  translate([radius * cos(angle), radius * sin(angle), 0])
+  translate([radius * cos(angle), radius * sin(angle), z])
     rotate([0, 0, angle])
       cube([width, strip_thickness_y, thickness]);
 }
 
 // === Central Disc + Hole ===
-module center_attachment_disc() {
+module spiral() {
   difference() {
-    // Disc
-    translate([0, 0, 0])
-      cylinder(h=center_disc_thickness, r=center_disc_radius, $fn=100);
+    // Spiral
+    spiral_strip_variable_size();
 
     // Hole
     translate([0, 0, -1])
-      cylinder(h=center_disc_thickness + 2, r=center_hole_radius, $fn=50);
+      cylinder(h=center_disc_thickness + 3, r=center_hole_radius, $fn=50);
   }
 }
 
 // === Bridge from spiral end to center (elevated) ===
 module bridge_to_top_disc_aligned() {
-  t = 1;
-  angle = 360 * (total_segments - 1.35) / segments_per_turn;
-  radius = start_radius + (end_radius - start_radius) * t;
+  // Compute last spiral segment position
+  t = (total_segments - 1) / total_segments;
+  angle = 360 * (total_segments - 1) / segments_per_turn;
+  radius = end_radius * pow(start_radius / end_radius, t);
 
   end_x = radius * cos(angle);
   end_y = radius * sin(angle);
+  z = max_thickness;
 
-  z = max_thickness / 2;
+  // Compute angle and length from (0,0) to spiral end
+  len = end_radius - radius - turns + max_width / 2 - min_width; // distance to center
 
-  // ✅ Add buffer to fully intersect spiral edge
-  len = sqrt(end_x * end_x + end_y * end_y) + max_width - min_width;
-
-  mid_x = end_x / 2;
-  mid_y = end_y / 2;
-
-  translate([mid_x + max_width - min_width, mid_y, z + max_thickness])
-    rotate([0, 0, angle])
-      cube([len, max_width, max_thickness], center=true);
+  // Build bridge from center to that point
+  translate([radius, 0, z])
+    rotate([0, 0, 0])
+      cube([len, min_width, max_thickness]);  // not centered
 }
 
 // === New disc at the top (for hanging)
@@ -94,4 +97,26 @@ module top_attachment_disc() {
       translate([0, 0, -1])
         cylinder(h = max_thickness + 2, r = center_hole_radius, $fn=50);
     }
+}
+
+// === Reinforce Bridge Joint ===
+module reinforce_bridge_joint() {
+  t = (total_segments - 1) / total_segments;
+  angle_deg = 360 * (total_segments - 1) / segments_per_turn;
+  radius = end_radius * pow(start_radius / end_radius, t);
+  z = max_thickness;
+
+  // Convert polar to cartesian
+  x = radius * cos(angle_deg);
+  y = radius * sin(angle_deg);
+
+  // Block dimensions
+  block_len = min_width * 1.5;
+  block_depth = strip_thickness_y * 2;
+  block_height = max_thickness * 2;
+
+  len = end_radius - radius - turns + max_width;
+
+  translate([len - min_width, 0, 0])
+    cube([block_len, block_depth, block_height]);
 }


### PR DESCRIPTION
## Why?
I saw the Ruth Asawa exhibit at SFMOMA this week and it inspired me on a work project and then I decided to design a model of a tornado spiral sculpture in OpenSCAD. The goal is to create a 3D printable model that captures the essence of Asawa's work while being functional as a hanging sculpture.

## How?
Added `tornado.scad`: a fully parameterized OpenSCAD script that generates a funnel-shaped, multi-turn spiral with user-settable dimensions, width profile, thickness profile, attachment discs (center and top), and optional hanging hook.

Redesigns include smooth variation of width and thickness along the spiral, integration of discs for robust hanging/attachment, and modular geometry for easier printing and assembly.

Introduces a reinforced bridge connector aligned between the spiral and top disc, with improved joint and customizable parameter.

https://github.com/user-attachments/assets/14f0f239-0ad3-43b2-8a60-74d25c1fec23